### PR TITLE
bug-fix (see description)

### DIFF
--- a/views/index.mjs
+++ b/views/index.mjs
@@ -83,7 +83,7 @@ export default function(){
     
             ipcMain.handle('action:close', ()=>{
                 if ( parentView.isFocused() ) parentView.close() ;
-                if ( childView.isFocused() )  childView.close()  ;
+                if ( !parentView.isDestroyed() && childView.isFocused() ) childView.close() ;
             })
 
         }


### PR DESCRIPTION
> Error occurred in handler for 'action:close': TypeError: Object has been destroyed

Bugfix:

```js
if ( !parentView.isDestroyed() && childView.isFocused() )
```

The single line presented above just proves that at the code-level (JavaScript) there is existing hierarchy of parent-child windows management, and thus we must check whether or not our main (parent) window, as in this case `parentView`, was destroyed, and if not, then we indeed allowed to proceed on `childView`, such as by calling `childView.close()` during respective IPC handling calls

--- 